### PR TITLE
fixed loading csv with quotes in fasta summary

### DIFF
--- a/enviroments/fasta_summary.yaml
+++ b/enviroments/fasta_summary.yaml
@@ -1,4 +1,6 @@
 channels:
+- bioconda
 - conda-forge
 dependencies:
 - blast=2.7.1
+- pandas

--- a/rules/paired_end/classification/report/summary/fasta_summary.snake
+++ b/rules/paired_end/classification/report/summary/fasta_summary.snake
@@ -48,6 +48,7 @@ rule fasta_summary__blast:
             {input.blast}\
             {params.min_query_coverage}\
             {params.max_target_seqs}\
+            {wildcards.reference}\
             {output.tsv}
         """
         

--- a/rules/paired_end/classification/report/summary/scripts/fasta_summary_blast.py
+++ b/rules/paired_end/classification/report/summary/scripts/fasta_summary_blast.py
@@ -1,10 +1,12 @@
 import sys
 import pandas as pd
+import csv
 
+blast = pd.read_csv(sys.argv[1], sep='\t', index_col=None, encoding='utf-8', quoting=csv.QUOTE_NONE)
 
-blast = pd.read_csv(sys.argv[1], sep='\t', index_col=None)
-min_query_coverage = sys.argv[2]
-max_target_seqs = sys.argv[3]
+min_query_coverage = float(sys.argv[2])
+max_target_seqs = int(sys.argv[3])
+reference = sys.argv[4]
 seqids, info_list = [], []
 
 for seqid, aligns in blast.groupby('qseqid'):
@@ -21,10 +23,10 @@ for seqid, aligns in blast.groupby('qseqid'):
 
     seqids.append(seqid)
     info_list.append({
-        'Homologue title (%s)' % wildcards.reference: ';'.join(aligns['stitle']),
-        'Homologue accession (%s)' % wildcards.reference: ';'.join(aligns['stitle']),
-        'Homologue link (%s)' % wildcards.reference: '<br />'.join(aligns.apply(create_link, axis=1))
+        'Homologue title (%s)' % reference: ';'.join(aligns['stitle']),
+        'Homologue accession (%s)' % reference: ';'.join(aligns['stitle']),
+        'Homologue link (%s)' % reference: '<br />'.join(aligns.apply(create_link, axis=1))
     })
 
 infos = pd.DataFrame(info_list, index=seqids)
-infos.to_csv(sys.argv[4], sep='\t')
+infos.to_csv(sys.argv[5], sep='\t')


### PR DESCRIPTION
- Quotes are now ignored in csv parser using `quoting=csv.QUOTE_NONE`. This is done because taxonomy mainly in cases when it is not curated, consists of strange stuff such as: "hesus Macaque CHR5 BAC CH250-342J4 (Children's Hospital Oakland Research Institute Rhesus macaque Adult Male BAC Library)", which contains just one single quote, which prompts the parser to find the second one.