### PR TITLE
Ivar consensus per regions

### DIFF
--- a/example/covseq/config_covseq.yaml
+++ b/example/covseq/config_covseq.yaml
@@ -82,9 +82,10 @@ variant:                                    # Identify variation in reads given 
 
 consensus:                              # consensus sequence
     fasta:                              # create consesnus sequence based on vcf of a sample and reference fasta
-        method: bcftools                # Allowed: 'bcftools', 'ivar'
+        method: bcftools                # Allowed: 'bcftools', 'ivar' (consensus per ref regions), 'ivar_nonregional'
         mask_lte_coverage: 4            # Valid for 'bcftools'. Mask bases with N where coverage is lower than or equal to parameter.
-        count_orphans: False            # Valid for ivar. True or False (def: False), whether to count anomalous read pairs in variant calling/
+        count_orphans: False            # Valid for ivar. True or False (def: False), whether to count anomalous read pairs in variant calling
+        no_base_alignment_quality: True # Valid for ivar. True or False (def: False), on True disable base alignment quality.
         max_depth: 8000                 # Valid for ivar. Int (def: 8000), limits the number of reads to load in memory per input file. Setting to 0 removes the limit.
         min_mapping_quality: 0          # Valid for ivar. Int (def: 0), minimum mapping quality for an alignment to be used.
         min_base_quality: 13            # Valid for ivar. Int (def: 13), minimum base quality for a base to be considered. Setting to 0 make the overlapping bases reappear, albeit with 0 quality.

--- a/example/genomic/config_corona.yaml
+++ b/example/genomic/config_corona.yaml
@@ -87,9 +87,10 @@ variant:                                    # Identify variation in reads given 
 
 consensus:                              # consensus sequence
     fasta:                              # create consesnus sequence based on vcf of a sample and reference fasta
-        method: bcftools                # Allowed: 'bcftools', 'ivar'
+        method: bcftools                # Allowed: 'bcftools', 'ivar' (consensus per ref regions), 'ivar_nonregional'
         mask_lte_coverage: 4            # Valid for 'bcftools'. Mask bases with N where coverage is lower than or equal to parameter.
-        count_orphans: False            # Valid for ivar. True or False (def: False), whether to count anomalous read pairs in variant calling/
+        count_orphans: False            # Valid for ivar. True or False (def: False), whether to count anomalous read pairs in variant calling
+        no_base_alignment_quality: True # Valid for ivar. True or False (def: False), on True disable base alignment quality.
         max_depth: 8000                 # Valid for ivar. Int (def: 8000), limits the number of reads to load in memory per input file. Setting to 0 removes the limit.
         min_mapping_quality: 0          # Valid for ivar. Int (def: 0), minimum mapping quality for an alignment to be used.
         min_base_quality: 13            # Valid for ivar. Int (def: 13), minimum base quality for a base to be considered. Setting to 0 make the overlapping bases reappear, albeit with 0 quality.

--- a/example/genomic/config_corona_consensus.yaml
+++ b/example/genomic/config_corona_consensus.yaml
@@ -94,9 +94,10 @@ variant:                                    # Identify variation in reads given 
 
 consensus:                              # consensus sequence
     fasta:                              # create consesnus sequence based on vcf of a sample and reference fasta
-        method: bcftools                # Allowed: 'bcftools', 'ivar'
+        method: bcftools                # Allowed: 'bcftools', 'ivar' (consensus per ref regions), 'ivar_nonregional'
         mask_lte_coverage: 4            # Valid for 'bcftools'. Mask bases with N where coverage is lower than or equal to parameter.
-        count_orphans: False            # Valid for ivar. True or False (def: False), whether to count anomalous read pairs in variant calling/
+        count_orphans: False            # Valid for ivar. True or False (def: False), whether to count anomalous read pairs in variant calling
+        no_base_alignment_quality: True # Valid for ivar. True or False (def: False), on True disable base alignment quality.
         max_depth: 8000                 # Valid for ivar. Int (def: 8000), limits the number of reads to load in memory per input file. Setting to 0 removes the limit.
         min_mapping_quality: 0          # Valid for ivar. Int (def: 0), minimum mapping quality for an alignment to be used.
         min_base_quality: 13            # Valid for ivar. Int (def: 13), minimum base quality for a base to be considered. Setting to 0 make the overlapping bases reappear, albeit with 0 quality.

--- a/rules/shared/consensus/fasta/ivar.snake
+++ b/rules/shared/consensus/fasta/ivar.snake
@@ -22,6 +22,7 @@ rule ivar__create_consensus_fasta:
     output:
         fasta = 'consensus/{reference}-{panel}/{sample}.fa'
     params:
+        out_prefix = 'consensus/{reference}-{panel}/{sample}',
         count_orphans = '--count-orphans' if method_config.get('count_orphans', False) else '',
         max_depth = method_config.get('max_depth', 8000),
         min_mapping_quality = method_config.get('min_mapping_quality', 0),
@@ -49,15 +50,15 @@ rule ivar__create_consensus_fasta:
                 {input.bam} \
                 2> {log.err} \
             | ivar consensus \
-                -p {wildcards.sample}_$REF \
+                -p {params.out_prefix}_$REF \
                 -i {wildcards.sample}_$REF \
                 -q {params.ivar_quality_threshold} \
                 -t {params.ivar_frequency_threshold} \
                 -m {params.ivar_min_depth} \
                 1> {log.out} \
                 2>> {log.err}; \
-            OUT_FILE="{wildcards.sample}_$REF".fa; \
-            QUAL_FILE="{wildcards.sample}_$REF".qual.txt; \
+            OUT_FILE="{params.out_prefix}_$REF".fa; \
+            QUAL_FILE="{params.out_prefix}_$REF".qual.txt; \
             cat $OUT_FILE \
                 >> {output.fasta}; \
             rm $OUT_FILE; \

--- a/rules/shared/consensus/fasta/ivar.snake
+++ b/rules/shared/consensus/fasta/ivar.snake
@@ -56,10 +56,11 @@ rule ivar__create_consensus_fasta:
                 -m {params.ivar_min_depth} \
                 1> {log.out} \
                 2>> {log.err}; \
-            out_file="{wildcards.sample}_$REF"; \
-            out_file+=".fa"; \
-            cat $out_file \
+            OUT_FILE="{wildcards.sample}_$REF".fa; \
+            QUAL_FILE="{wildcards.sample}_$REF".qual.txt; \
+            cat $OUT_FILE \
                 >> {output.fasta}; \
-            rm $out_file; \
+            rm $OUT_FILE; \
+            rm $QUAL_FILE; \
         done;
         '''

--- a/rules/shared/consensus/fasta/ivar.snake
+++ b/rules/shared/consensus/fasta/ivar.snake
@@ -5,7 +5,9 @@ rule ivar__create_consensus_fasta:
     Calls 'samtools mpileup' piped into 'ivar consensus'.
 
     :input bam: mapping output in the final postprocessed stage.
-    :param count_orphans: True or False (def: False), whether to count anomalous read pairs in variant calling/
+    :input fai: indexed fasta to obtain regions.
+    :param count_orphans: True or False (def: False), whether to count anomalous read pairs in variant calling
+    :param no_base_alignment_quality: True or False (def: False), disable base alignment quality.
     :param max_depth: Int (def: 8000), limits the number of reads to load in memory per input file. Setting to 0 removes the limit.
     :param min_mapping_quality: Int (def: 0), minimum mapping quality for an alignment to be used.
     :param min_base_quality: Int (def: 13), minimum base quality for a base to be considered. Setting to 0 make the overlapping bases reappear, albeit with 0 quality.
@@ -16,7 +18,7 @@ rule ivar__create_consensus_fasta:
     """
     input:
         bam   = 'mapping/{{reference}}/{map_type}/{{sample}}.bam'.format(map_type=pipeline.postprocessed_map_type),
-        reference/{reference}/{reference}.fa.fai
+        fai   = 'reference/{reference}/{reference}.fa.fai',
     output:
         fasta = 'consensus/{reference}-{panel}/{sample}.fa'
     params:
@@ -34,7 +36,7 @@ rule ivar__create_consensus_fasta:
     conda:
         config['snakelines_dir'] + '/environments/ivar_consensus.yaml'
     shell:
-        """
+        '''
         for REF in `cut -f 1 {input.fai}`; do \
             samtools mpileup \
                 --region $REF \
@@ -47,15 +49,17 @@ rule ivar__create_consensus_fasta:
                 {input.bam} \
                 2> {log.err} \
             | ivar consensus \
-                -p $REF \
+                -p {wildcards.sample}_$REF \
                 -i $REF \
                 -q {params.ivar_quality_threshold} \
                 -t {params.ivar_frequency_threshold} \
                 -m {params.ivar_min_depth} \
                 1> {log.out} \
                 2>> {log.err}; \
-            cat ${REF}.fa \
+            out_file="{wildcards.sample}_$REF"; \
+            out_file+=".fa"; \
+            cat $out_file \
                 >> {output.fasta}; \
-            rm ${REF}.fa; \
+            rm $out_file; \
         done;
-        """
+        '''

--- a/rules/shared/consensus/fasta/ivar.snake
+++ b/rules/shared/consensus/fasta/ivar.snake
@@ -50,7 +50,7 @@ rule ivar__create_consensus_fasta:
                 2> {log.err} \
             | ivar consensus \
                 -p {wildcards.sample}_$REF \
-                -i $REF \
+                -i {wildcards.sample}_$REF \
                 -q {params.ivar_quality_threshold} \
                 -t {params.ivar_frequency_threshold} \
                 -m {params.ivar_min_depth} \

--- a/rules/shared/consensus/fasta/ivar_nonregional.snake
+++ b/rules/shared/consensus/fasta/ivar_nonregional.snake
@@ -1,11 +1,12 @@
-rule ivar__create_consensus_fasta:
+rule ivar__create_consensus_fasta_nonregional:
     """
     Create consensus sequence using samtools and ivar
 
     Calls 'samtools mpileup' piped into 'ivar consensus'.
 
     :input bam: mapping output in the final postprocessed stage.
-    :param count_orphans: True or False (def: False), whether to count anomalous read pairs in variant calling/
+    :param count_orphans: True or False (def: False), whether to count anomalous read pairs in variant calling
+    :param no_base_alignment_quality: True or False (def: False), disable base alignment quality.
     :param max_depth: Int (def: 8000), limits the number of reads to load in memory per input file. Setting to 0 removes the limit.
     :param min_mapping_quality: Int (def: 0), minimum mapping quality for an alignment to be used.
     :param min_base_quality: Int (def: 13), minimum base quality for a base to be considered. Setting to 0 make the overlapping bases reappear, albeit with 0 quality.
@@ -23,6 +24,7 @@ rule ivar__create_consensus_fasta:
         count_orphans = '--count-orphans' if method_config.get('count_orphans', False) else '',
         max_depth = method_config.get('max_depth', 8000),
         min_mapping_quality = method_config.get('min_mapping_quality', 0),
+        no_base_alignment_quality = '--no-BAQ' if method_config.get('no_base_alignment_quality', False) else '',
         min_base_quality = method_config.get('min_base_quality', 13),
         ivar_quality_threshold = method_config.get('ivar_quality_threshold', 20),
         ivar_frequency_threshold = method_config.get('ivar_frequency_threshold', 0),
@@ -35,6 +37,7 @@ rule ivar__create_consensus_fasta:
     shell:
         """
         samtools mpileup \
+            {params.no_base_alignment_quality} \
             -aa \
             {params.count_orphans} \
             --max-depth {params.max_depth} \

--- a/rules/shared/consensus/fasta/ivar_nonsegmental.snake
+++ b/rules/shared/consensus/fasta/ivar_nonsegmental.snake
@@ -16,15 +16,14 @@ rule ivar__create_consensus_fasta:
     """
     input:
         bam   = 'mapping/{{reference}}/{map_type}/{{sample}}.bam'.format(map_type=pipeline.postprocessed_map_type),
-        reference/{reference}/{reference}.fa.fai
     output:
         fasta = 'consensus/{reference}-{panel}/{sample}.fa'
     params:
+        out_prefix = 'consensus/{reference}-{panel}/{sample}',
         count_orphans = '--count-orphans' if method_config.get('count_orphans', False) else '',
         max_depth = method_config.get('max_depth', 8000),
         min_mapping_quality = method_config.get('min_mapping_quality', 0),
         min_base_quality = method_config.get('min_base_quality', 13),
-        no_base_alignment_quality = '--no-BAQ' if method_config.get('no_base_alignment_quality', False) else '',
         ivar_quality_threshold = method_config.get('ivar_quality_threshold', 20),
         ivar_frequency_threshold = method_config.get('ivar_frequency_threshold', 0),
         ivar_min_depth = method_config.get('ivar_min_depth', 10),
@@ -35,27 +34,19 @@ rule ivar__create_consensus_fasta:
         config['snakelines_dir'] + '/environments/ivar_consensus.yaml'
     shell:
         """
-        for REF in `cut -f 1 {input.fai}`; do \
-            samtools mpileup \
-                --region $REF \
-                {params.no_base_alignment_quality} \
-                -aa \
-                {params.count_orphans} \
-                --max-depth {params.max_depth} \
-                --min-MQ {params.min_mapping_quality} \
-                --min-BQ {params.min_base_quality} \
-                {input.bam} \
-                2> {log.err} \
-            | ivar consensus \
-                -p $REF \
-                -i $REF \
-                -q {params.ivar_quality_threshold} \
-                -t {params.ivar_frequency_threshold} \
-                -m {params.ivar_min_depth} \
-                1> {log.out} \
-                2>> {log.err}; \
-            cat ${REF}.fa \
-                >> {output.fasta}; \
-            rm ${REF}.fa; \
-        done;
+        samtools mpileup \
+            -aa \
+            {params.count_orphans} \
+            --max-depth {params.max_depth} \
+            --min-MQ {params.min_mapping_quality} \
+            --min-BQ {params.min_base_quality} \
+            {input.bam} \
+            2> {log.err} \
+        | ivar consensus \
+            -p {params.out_prefix} \
+            -q {params.ivar_quality_threshold} \
+            -t {params.ivar_frequency_threshold} \
+            -m {params.ivar_min_depth} \
+        1> {log.out} \
+        2>> {log.err}
         """


### PR DESCRIPTION
- Previous Ivar consensus moved to `ivar_nonregional` method.
- Added new method to get consensus using ivar per reference regions - method `ivar`
- Exposed `no_base_alignment_quality` option in config for `ivar`