### PR TITLE
Fix fastqc temp dir

### DIFF
--- a/rules/paired_end/reads/report/quality_report/fastqc.snake
+++ b/rules/paired_end/reads/report/quality_report/fastqc.snake
@@ -81,13 +81,6 @@ rule fastqc__quality_report:
         err = 'reads/{read_type}/stat{stats_type}/log/{fastq}.err',
     conda:
         config['snakelines_dir'] + '/environments/fastqc.yaml'
-    shell:
-        """
-        fastqc \
-            -o reads/{wildcards.read_type}/stat{wildcards.stats_type} \
-            --extract \
-            --threads {threads} \
-            {input.reads} \
-        >  {log.out} \
-        2> {log.err}
-        """
+    script:
+        "scripts/wrapper.py"
+

--- a/rules/paired_end/reads/report/quality_report/scripts/wrapper.py
+++ b/rules/paired_end/reads/report/quality_report/scripts/wrapper.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+
+from snakemake.shell import shell
+
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    shell(
+        "fastqc "
+        " --outdir {tmpdir}"
+        " --extract"
+        " --threads {snakemake.threads}"
+        " --dir {tmpdir}"
+        " {snakemake.input.reads}"
+        " >  {snakemake.log.out}"
+        " 2> {snakemake.log.err}"
+    )
+
+    PRESUMED_SUFFIX = ".fastq.gz"
+    if not snakemake.input.reads.endswith(PRESUMED_SUFFIX):
+        raise ValueError(f"{snakemake.input.reads} does not ends with {PRESUMED_SUFFIX}")
+
+    base_name = os.path.basename(snakemake.input.reads).replace(".fastq.gz", "")
+    print("basename",base_name)
+    html_path = os.path.join(tmpdir, f"{base_name}_fastqc.html")
+    zip_path = os.path.join(tmpdir, f"{base_name}_fastqc.zip")
+
+    fastqc_datapath = os.path.join(tmpdir, f"{base_name}_fastqc", "fastqc_data.txt")
+    summary_path = os.path.join(tmpdir, f"{base_name}_fastqc", "summary.txt")
+
+    shell("ls {tmpdir}")
+    shell("mv {html_path} {snakemake.output.html}")
+    shell("mv {zip_path} {snakemake.output.zip}")
+    shell("mv {fastqc_datapath} {snakemake.output.data}")
+    shell("mv {summary_path} {snakemake.output.txt}")
+

--- a/rules/paired_end/reads/report/quality_report/scripts/wrapper.py
+++ b/rules/paired_end/reads/report/quality_report/scripts/wrapper.py
@@ -21,14 +21,12 @@ with tempfile.TemporaryDirectory() as tmpdir:
         raise ValueError(f"{snakemake.input.reads} does not ends with {PRESUMED_SUFFIX}")
 
     base_name = os.path.basename(snakemake.input.reads).replace(".fastq.gz", "")
-    print("basename",base_name)
     html_path = os.path.join(tmpdir, f"{base_name}_fastqc.html")
     zip_path = os.path.join(tmpdir, f"{base_name}_fastqc.zip")
 
     fastqc_datapath = os.path.join(tmpdir, f"{base_name}_fastqc", "fastqc_data.txt")
     summary_path = os.path.join(tmpdir, f"{base_name}_fastqc", "summary.txt")
 
-    shell("ls {tmpdir}")
     shell("mv {html_path} {snakemake.output.html}")
     shell("mv {zip_path} {snakemake.output.zip}")
     shell("mv {fastqc_datapath} {snakemake.output.data}")


### PR DESCRIPTION
- Changed running fastqc reports to run in temporary directory to prevent race conditions
- Added wrapper script to  use temporary directory as the context manager