### PR TITLE
fix: picard temp dir to use context manager

### DIFF
--- a/rules/shared/mapping/postprocess/deduplicated/picard.snake
+++ b/rules/shared/mapping/postprocess/deduplicated/picard.snake
@@ -21,18 +21,6 @@ rule picard__mark_duplicates:
             '{mapper}/{reference}/deduplicated/log/{sample}.benchmark'
     conda:
         config['snakelines_dir'] + '/environments/picard.yaml'
-    shell:
-        """
-        TEMP_DIR=$(mktemp -d {params.tmp_dir}/XXXXXXXXXXX)
+    script:
+        "scripts/picard_wrapper.py"
 
-        picard MarkDuplicates \
-            I={input.bam} \
-            O={output.bam} \
-            M={log.stat} \
-            TMP_DIR=$TEMP_DIR \
-            VALIDATION_STRINGENCY=SILENT \
-        >  {log.out} \
-        2> {log.err}
-
-        rm -r $TEMP_DIR
-        """

--- a/rules/shared/mapping/postprocess/deduplicated/picard.snake
+++ b/rules/shared/mapping/postprocess/deduplicated/picard.snake
@@ -18,9 +18,8 @@ rule picard__mark_duplicates:
         err  = '{mapper}/{reference}/deduplicated/log/{sample}.err',
         stat = '{mapper}/{reference}/deduplicated/log/{sample}.stats'
     benchmark:
-            '{mapper}/{reference}/deduplicated/log/{sample}.benchmark'
+        '{mapper}/{reference}/deduplicated/log/{sample}.benchmark'
     conda:
         config['snakelines_dir'] + '/environments/picard.yaml'
     script:
         "scripts/picard_wrapper.py"
-

--- a/rules/shared/mapping/postprocess/deduplicated/picard.snake
+++ b/rules/shared/mapping/postprocess/deduplicated/picard.snake
@@ -11,8 +11,6 @@ rule picard__mark_duplicates:
         bai  = '{{mapper}}/{{reference}}/{map_type}/{{sample}}.bam.bai'.format(map_type=method_config['input_map_type'])
     output:
         bam  = configured_temp('{mapper}/{reference}/deduplicated/{sample}.bam')
-    params:
-        tmp_dir = config['tmp_dir']
     log:
         out  = '{mapper}/{reference}/deduplicated/log/{sample}.log',
         err  = '{mapper}/{reference}/deduplicated/log/{sample}.err',

--- a/rules/shared/mapping/postprocess/deduplicated/scripts/picard_wrapper.py
+++ b/rules/shared/mapping/postprocess/deduplicated/scripts/picard_wrapper.py
@@ -1,0 +1,18 @@
+import tempfile
+from snakemake.shell import shell
+
+
+sys.stderr = open(snakemake.log.err, "w")
+sys.stdout = open(snakemake.log.out, "w")
+
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    shell(
+        "picard MarkDuplicates"
+        " I={snakemake.input.bam}"
+        " O={snakemake.output.bam}"
+        " M={snakemake.log.stat}"
+        " TMP_DIR={tmpdir}"
+        " VALIDATION_STRINGENCY=SILENT"
+    )
+

--- a/rules/shared/mapping/postprocess/deduplicated/scripts/picard_wrapper.py
+++ b/rules/shared/mapping/postprocess/deduplicated/scripts/picard_wrapper.py
@@ -15,4 +15,3 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " TMP_DIR={tmpdir}"
         " VALIDATION_STRINGENCY=SILENT"
     )
-

--- a/rules/shared/mapping/postprocess/deduplicated/scripts/picard_wrapper.py
+++ b/rules/shared/mapping/postprocess/deduplicated/scripts/picard_wrapper.py
@@ -14,5 +14,5 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " M={snakemake.log.stat}"
         " TMP_DIR={tmpdir}"
         " VALIDATION_STRINGENCY=SILENT"
-        " 1>{snakemake.log.out} 2>{snakemake.log.err}"
+        " 1>> {snakemake.log.out} 2>> {snakemake.log.err}"
     )

--- a/rules/shared/mapping/postprocess/deduplicated/scripts/picard_wrapper.py
+++ b/rules/shared/mapping/postprocess/deduplicated/scripts/picard_wrapper.py
@@ -14,4 +14,5 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " M={snakemake.log.stat}"
         " TMP_DIR={tmpdir}"
         " VALIDATION_STRINGENCY=SILENT"
+        " 1>{snakemake.log.out} 2>{snakemake.log.err}"
     )

--- a/rules/shared/variant/caller/scripts/gatk_select_variants.py
+++ b/rules/shared/variant/caller/scripts/gatk_select_variants.py
@@ -13,5 +13,5 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " --reference {snakemake.input.fasta}"
         " --output {snakemake.output.vcf}"
         " --tmp-dir {tmpdir}"
-        " 1>{snakemake.log.out} 2>{snakemake.log.err}"
+        " 1>> {snakemake.log.out} 2>> {snakemake.log.err}"
     )

--- a/rules/shared/variant/caller/scripts/gatk_select_variants.py
+++ b/rules/shared/variant/caller/scripts/gatk_select_variants.py
@@ -13,5 +13,5 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " --reference {snakemake.input.fasta}"
         " --output {snakemake.output.vcf}"
         " --tmp-dir {tmpdir}"
+        " 1>{snakemake.log.out} 2>{snakemake.log.err}"
     )
-


### PR DESCRIPTION
- usage of temp directory in picard markDuplicates is replaced by the context manager which handles the removal of temp dir automatically. Further, this also solves the rare error `rm: cannot remove {temp_dir_XY}: Device or resource busy` when calling `rm -r $TEMP_DIR` at the end of the rule